### PR TITLE
Fix pylint warning `no-else-return`

### DIFF
--- a/courses/fields.py
+++ b/courses/fields.py
@@ -24,5 +24,4 @@ class OrderField(models.PositiveIntegerField):
                 value = 0
             setattr(model_instance, self.attname, value)
             return value
-        else:
-            return super(OrderField, self).pre_save(model_instance, add)
+        return super(OrderField, self).pre_save(model_instance, add)

--- a/courses/views.py
+++ b/courses/views.py
@@ -145,10 +145,8 @@ def add_review(request, subject):
         possibly_award_badge("reviews_course", user=request.user)
         messages.success(request, 'Review added.')
         return HttpResponseRedirect(reverse('courses:course_detail', args=(subject.slug,)))
-    else:
-        messages.warning(request, 'Error Occured.')
-        return HttpResponseRedirect(reverse('courses:course_detail', args=(subject.slug,)))
-    return render(request, 'courses/course/detail.html', {'subject': subject, 'form': form})
+    messages.warning(request, 'Error Occured.')
+    return HttpResponseRedirect(reverse('courses:course_detail', args=(subject.slug,)))
 
 
 class ModuleOrderView(CsrfExemptMixin, JsonRequestResponseMixin, View):

--- a/students/views/classroom.py
+++ b/students/views/classroom.py
@@ -15,12 +15,10 @@ class SignupView(TemplateView):
 
 def index(request):
     if request.user.is_authenticated:
-         if request.user.is_teacher:
-             return redirect('students:teacher_quiz_change_list')
-         else:
-             return redirect('students:student_quiz_list')
-    else:
-        return redirect('courses:course_list')
+        if request.user.is_teacher:
+            return redirect('students:teacher_quiz_change_list')
+        return redirect('students:student_quiz_list')
+    return redirect('courses:course_list')
 
 
 def contact_us_view(request):
@@ -51,8 +49,6 @@ def contact_us_view(request):
             email.send()
             messages.success(request, _('Thank you ! We will check in as soon as possible ;-)'))
             return redirect('students:contact_us')
-        else:
-            messages.info(request, _('Oops ! Message not send...'))
     return render(request, 'students/contact/contact_form.html', { 'form': form_class })
 
 

--- a/students/views/students.py
+++ b/students/views/students.py
@@ -168,15 +168,14 @@ def take_quiz(request, pk):
                 student_answer.save()
                 if student.get_unanswered_questions(quiz).exists():
                     return redirect('students:take_quiz', pk)
+                correct_answers = student.quiz_answers.filter(answer__question__quiz=quiz, answer__is_correct=True).count()
+                score = round((correct_answers / total_questions ) * 100.0, 2)
+                TakenQuiz.objects.create(student=student, quiz=quiz, score=score)
+                if score < 50.0:
+                    messages.warning(request, 'Good luck for next time! Your score for this quiz %s was %s.' % (quiz.name, score))
                 else:
-                    correct_answers = student.quiz_answers.filter(answer__question__quiz=quiz, answer__is_correct=True).count()
-                    score = round((correct_answers / total_questions ) * 100.0, 2)
-                    TakenQuiz.objects.create(student=student, quiz=quiz, score=score)
-                    if score < 50.0:
-                        messages.warning(request, 'Good luck for next time! Your score for this quiz %s was %s.' % (quiz.name, score))
-                    else:
-                        messages.success(request, 'Fantastic! You completed the quiz %s with success! Your scored %s points.' % (quiz.name, score))
-                    return redirect('students:student_quiz_list')
+                    messages.success(request, 'Fantastic! You completed the quiz %s with success! Your scored %s points.' % (quiz.name, score))
+                return redirect('students:student_quiz_list')
     else:
         form = TakeQuizForm(question=question)
 


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `no-else-return`.
"Used in order to highlight an unnecessary block of code following an if containing a return statement. As such, it will warn when it encounters an else following a chain of ifs, all of them containing a return statement.. See [https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/no-else-return.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.